### PR TITLE
Update RS chat-messages module

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ const RemoteStorage = require("remotestoragejs");
 const ChatMessages  = require("remotestorage-module-chat-messages");
 
 const remoteStorage = new RemoteStorage({
+  cache: false, // TODO re-enable default caching (SEEN) when getListing maxAge is fixed
   modules: [ ChatMessages ]
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -459,9 +459,9 @@
       }
     },
     "remotestorage-module-chat-messages": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/remotestorage-module-chat-messages/-/remotestorage-module-chat-messages-2.0.0.tgz",
-      "integrity": "sha512-V9xdQfVX34fp5dZskg3hulqHcFgYD0fcCbipLULxxJMT98aK0WUyaFKk09ZK7HWIExcPiUj/Oo1JkGjUuYBJjw=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/remotestorage-module-chat-messages/-/remotestorage-module-chat-messages-2.1.0.tgz",
+      "integrity": "sha512-8hxbzG0aSPMTj5Kasio1LHyHeeWh/NqKZ5UDW+JCZfV5yCfJW72QKJrs9/JlgOajizgfDBly9j6p1fOgfNI00g=="
     },
     "remotestoragejs": {
       "version": "2.0.0-beta.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "repository": "https://github.com/67P/hubot-remotestorage-logger",
   "dependencies": {
     "hubot": "3.x",
-    "remotestorage-module-chat-messages": "^2.0.0",
+    "remotestorage-module-chat-messages": "^2.1.0",
     "remotestoragejs": "^2.0.0-beta.1"
   },
   "peerDependencies": {


### PR DESCRIPTION
Automatically adds a metadata document with the paths of the first and last daily archive to chat channels in RS.

We need to deactivate caching for now, due to what looks like a bug with rs.js's `getListing()` and its `maxAge` argument.