### PR TITLE
Allow custom server names again

### DIFF
--- a/index.js
+++ b/index.js
@@ -143,7 +143,7 @@ module.exports = function (robot) {
         archive.channelName = room;
         archive.service = {
           protocol: 'IRC',
-          domain: process.env.HUBOT_IRC_SERVER
+          domain: process.env.RS_LOGGER_SERVER_NAME || process.env.HUBOT_IRC_SERVER
         }
         break;
       case 'xmpp':


### PR DESCRIPTION
Necessary e.g. when using a bouncer to connect, so the IRC host is different from the one actually being logged.